### PR TITLE
Use docker exec command to transfer the test-kitchen's sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# <a name="title"></a> Kitchen::DockerCli [![Gem Version](https://badge.fury.io/rb/kitchen-docker_cli.svg)](http://badge.fury.io/rb/kitchen-docker_cli) [![Build Status](https://travis-ci.org/marcy-terui/kitchen-docker_cli.svg?branch=master)](https://travis-ci.org/marcy-terui/kitchen-docker_cli) [![Coverage Status](https://coveralls.io/repos/marcy-terui/kitchen-docker_cli/badge.png)](https://coveralls.io/r/marcy-terui/kitchen-docker_cli) [![Code Climate](https://codeclimate.com/github/marcy-terui/kitchen-docker_cli/badges/gpa.svg)](https://codeclimate.com/github/marcy-terui/kitchen-docker_cli)
-
+# <a name="title"></a> Kitchen::DockerCli [![Gem Version](https://badge.fury.io/rb/kitchen-docker_cli.svg)](http://badge.fury.io/rb/kitchen-docker_cli) [![Build Status](https://travis-ci.org/marcy-terui/kitchen-docker_cli.svg?branch=master)](https://travis-ci.org/marcy-terui/kitchen-docker_cli) [![Coverage Status](https://coveralls.io/repos/marcy-terui/kitchen-docker_cli/badge.png)](https://coveralls.io/r/marcy-terui/kitchen-docker_cli) 
 A Test Kitchen Driver for Docker command line interface.
 
 This plugin is created with only Docker CLI functions.  


### PR DESCRIPTION
Previously the host's temporary directory had been mount on all containers.  
Therefore, We had several problems.

Those problems were solved by this PR.
