### PR TITLE
upload via docker data dir

### DIFF
--- a/lib/kitchen/transport/docker_cli.rb
+++ b/lib/kitchen/transport/docker_cli.rb
@@ -18,6 +18,7 @@
 
 require "kitchen"
 require 'thor/util'
+require 'fileutils'
 
 module Kitchen
   module Transport
@@ -59,14 +60,11 @@ module Kitchen
         end
 
         def upload(locals, remote)
-          cmd = "mkdir -p #{remote} && rm -rf #{remote}/*"
-          execute(cmd)
+          FileUtils.rm_rf(Dir.glob(@options[:upload_proxy_dir] + "/*"), :secure => true)
           Array(locals).each do |local|
-            remote_cmd = "tar x -C #{remote}"
-            remote_cmd = "#{binary} #{docker_exec_command(@options[:container_id], remote_cmd, :interactive => true)}"
-            local_cmd  = "cd #{File.dirname(local)} && tar cf - ./#{File.basename(local)}"
-            run_command("#{local_cmd} | #{remote_cmd}")
+            FileUtils.cp_r(local, @options[:upload_proxy_dir], :remove_destination => true)
           end
+          execute("cp -r /kitchen-docker_cli/* #{remote}")
         end
 
         def docker_exec_command(container_id, cmd, opt = {})


### PR DESCRIPTION
There are 2 problems.

1. upload requires same version(BSD or GNU) `tar` command on local and remote, otherwise it raises annoying warnings ( cf. http://superuser.com/questions/318809/linux-os-x-tar-incompatibility-tarballs-created-on-os-x-give-errors-when-unt)
1. it always removes all files under remote dir, so when multiple files in the same directory are uploaded, existing files are removed one after another. This causes an error while `kitchen verify` with busser-serverspec.

To avoid these problems, I decided to mount a directory on container and communicate via it.

Is this reasonable approach? Any other ideas?

Thanks in advance.