### PR TITLE
option to pass Docker build context: build_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ environment:
   LANG: ja_JP.UTF-8
 ```
 
+### build_context
+
+Pass the basedir as the Docker build context: 'docker build <options> .' Default is 'false'.
+
 ### no_cache
 
 Not use the cached image on `docker build`.

--- a/lib/kitchen/driver/docker_cli.rb
+++ b/lib/kitchen/driver/docker_cli.rb
@@ -29,6 +29,7 @@ module Kitchen
     class DockerCli < Kitchen::Driver::Base
 
       default_config :no_cache, false
+      default_config :build_context, false
       default_config :command, 'sh -c \'while true; do sleep 1d; done;\''
       default_config :privileged, false
       default_config :instance_host_name, false
@@ -85,7 +86,11 @@ module Kitchen
       def docker_build_command
         cmd = String.new('build')
         cmd << ' --no-cache' if config[:no_cache]
-        cmd << ' -'
+        if config[:build_context]
+          cmd << ' .'
+        else
+          cmd << ' -'
+        end
       end
 
       def docker_run_command(image)

--- a/lib/kitchen/driver/docker_cli_version.rb
+++ b/lib/kitchen/driver/docker_cli_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for DockerCli Kitchen driver
-    DOCKER_CLI_VERSION = '0.14.0'
+    DOCKER_CLI_VERSION = '0.14.1'
   end
 end

--- a/spec/kitchen/driver/docker_cli_spec.rb
+++ b/spec/kitchen/driver/docker_cli_spec.rb
@@ -74,6 +74,14 @@ describe Kitchen::Driver::DockerCli, "docker_build_command" do
     @docker_cli = Kitchen::Driver::DockerCli.new(config)
   end
 
+  context 'build_context' do
+    let(:config)	{ {:build_context => true} }
+    
+    example do
+      expect(@docker_cli.docker_build_command).to eq 'build .'
+    end
+  end
+
   context 'default' do
     let(:config)       { {:no_cache => true} }
 
@@ -89,6 +97,7 @@ describe Kitchen::Driver::DockerCli, "docker_build_command" do
       expect(@docker_cli.docker_build_command).to eq 'build -'
     end
   end
+
 end
 
 describe Kitchen::Driver::DockerCli, "docker_run_command" do


### PR DESCRIPTION
First pass at solving the problem of docker_build_command not passing the Docker build context. Added non-default option, 'build_context', which when present/set to true will modify the command-line appropriately. Also added tests and entries in README.