### PR TITLE
add instance_container_name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ Examples:
   container_name: web
 ```
 
+### instance_container_name
+
+Use instance name to container_name.
+
+The default value is `false`.
+
+Examples:
+
+```yml
+  instance_container_name: true
+```
+
 ### network
 
 Set the Network mode for the container.  
@@ -201,6 +213,7 @@ Examples:
 ```
 
 ### instance_host_name
+
 Use instance name to hostname.
 
 The default value is `false`.

--- a/lib/kitchen/driver/docker_cli.rb
+++ b/lib/kitchen/driver/docker_cli.rb
@@ -33,6 +33,7 @@ module Kitchen
       default_config :command, 'sh -c \'while true; do sleep 1d; done;\''
       default_config :privileged, false
       default_config :instance_host_name, false
+      default_config :instance_container_name, false
       default_config :transport, "docker_cli"
       default_config :dockerfile_vars, {}
       default_config :skip_preparation, false
@@ -100,7 +101,11 @@ module Kitchen
 
       def docker_run_command(image)
         cmd = String.new("run -d -t")
-        cmd << " --name #{config[:container_name]}" if config[:container_name]
+        if config[:container_name]
+          cmd << " --name #{config[:container_name]}"
+        elsif config[:instance_container_name]
+          cmd << " --name #{instance.name}"
+        end
         cmd << ' -P' if config[:publish_all]
         cmd << " -m #{config[:memory_limit]}" if config[:memory_limit]
         cmd << " -c #{config[:cpu_shares]}" if config[:cpu_shares]


### PR DESCRIPTION
Very similar to instance_host_name option, it is useful to have a deterministic container name.