### PR TITLE
Add ability to configure security options

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ Examples:
   privileged: true
 ```
 
+### security_opt
+
+Define the seccomp security profile to use.
+
+The default value is `nil`.
+
+Examples:
+
+```yml
+  security_opt: seccomp=unconfined
+```
+
 ### container_name
 
 Set the name of container to link other container(s).

--- a/lib/kitchen/driver/docker_cli.rb
+++ b/lib/kitchen/driver/docker_cli.rb
@@ -109,6 +109,7 @@ module Kitchen
         cmd << ' -P' if config[:publish_all]
         cmd << " -m #{config[:memory_limit]}" if config[:memory_limit]
         cmd << " -c #{config[:cpu_shares]}" if config[:cpu_shares]
+        cmd << " --security-opt #{config[:security_opt]}" if config[:security_opt]
         cmd << ' --privileged' if config[:privileged]
         cmd << " --net #{config[:network]}" if config[:network]
         if config[:hostname]


### PR DESCRIPTION
I would like to add the ability to configure security options.
For example running container without the default seccomp profile
could be really useful when docker has been compiled with this
kernel feature.