### PR TITLE
Strengthen destroy, add destroy_container_name opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ Examples:
   instance_container_name: true
 ```
 
+
+### destroy_container_name
+
+Improve destroy action when containers have defined names.
+
+When enabled, "kitchen destroy" will always try to remove suite containers with their name (if defined by container_name or instance_container_name options) in addition to with the id defined in the current state. This allows a clean removal of containers even if the state is corrupted or was removed.
+
+The default value is `true`.
+
+Examples:
+
+```yml
+  destroy_container_name: false
+```
+
 ### network
 
 Set the Network mode for the container.  


### PR DESCRIPTION
It may happen that states in .kitchen/ are not valid (because containers have been removed manually) or have been deleted. In this case, "kitchen destroy" may fail continuously.

This patches strengthens destroy command in two ways:

1/ by checking if a container exists before trying to remove it

2/ by adding a new option "destroy_container_name" which when enabled (by default) makes "kitchen destroy" try to remove suite containers with their name (if defined by container_name or instance_container_name options) in addition to with the id defined in the current state (kitchen files).