### PR TITLE
Make it possible to use custom Dockerfile when setting build_context to true

### DIFF
--- a/lib/kitchen/driver/docker_cli.rb
+++ b/lib/kitchen/driver/docker_cli.rb
@@ -100,6 +100,13 @@ module Kitchen
       def docker_build_command
         cmd = String.new('build')
         cmd << ' --no-cache' if config[:no_cache]
+        if config[:dockerfile]
+          dockerfile_contents = docker_file()
+          # save the Dockerfile contents rendered with ERB variables
+          dockerfile = "#{config[:kitchen_root]}/.kitchen/#{config[:dockerfile]}_#{instance.name}_rendered"
+          File.write(dockerfile, dockerfile_contents)
+          cmd << " -f #{dockerfile}"
+        end
         if config[:build_context]
           cmd << ' .'
         else


### PR DESCRIPTION
A fix idea for issue: #35 .

This PR provides the change: if custom_dockerfile is set, then it will be rendered using ERB variables and saved to a local file. Then the local file will be passed to `docker build` command. Then, on `kitchen destroy`, that rendered Dockerfile is removed.

This is not the prettiest solution, because I didn't change the line: https://github.com/marcy-terui/kitchen-docker_cli/blob/master/lib/kitchen/driver/docker_cli.rb#L87 . Do you think that `:input => docker_file` could be removed? Or am I missing some clearer and simpler solution?