### PR TITLE
Add build_pull opt to pull the latest docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ environment:
 
 Pass the basedir as the Docker build context: 'docker build <options> .' Default is 'false'.
 
+### build_pull
+
+Set option `--pull` to the defined value on `docker build`.
+
+The default value is nil which is currently interpreted as `false` by Docker.
+
+```yml
+  build_pull: true
+```
+
 ### no_cache
 
 Not use the cached image on `docker build`.

--- a/lib/kitchen/driver/docker_cli.rb
+++ b/lib/kitchen/driver/docker_cli.rb
@@ -99,6 +99,7 @@ module Kitchen
 
       def docker_build_command
         cmd = String.new('build')
+        cmd << " --pull=#{config[:build_pull]}" if config[:build_pull]
         cmd << ' --no-cache' if config[:no_cache]
         if config[:build_context]
           cmd << ' .'

--- a/spec/kitchen/driver/docker_cli_spec.rb
+++ b/spec/kitchen/driver/docker_cli_spec.rb
@@ -75,10 +75,18 @@ describe Kitchen::Driver::DockerCli, "#docker_build_command" do
   end
 
   context 'build_context' do
-    let(:config)	{ {:build_context => true} }
+    let(:config)       { {:build_context => true} }
 
     example do
       expect(@docker_cli.docker_build_command).to eq 'build .'
+    end
+  end
+
+  context 'build_pull set to true' do
+    let(:config)       { {:build_pull => true} }
+
+    example do
+      expect(@docker_cli.docker_build_command).to include '--pull=true'
     end
   end
 


### PR DESCRIPTION
By setting build_pull to true, kitchen will automatically pull the latest docker image. By default, it uses docker default which is false.