### PR TITLE
Add pre_create_command to driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,18 @@ Example:
   docker_base: sudo /path/to/lxc-console
 ```
 
+### pre_create_command
+
+A script or shell command to run locally prior to creating the
+container.  Used to prep the build environment, e.g. performing a login
+to a private docker repository where the test images are housed.
+
+Example:
+
+```yml
+  pre_create_command: ./path/to/script.sh
+```
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker_cli.rb
+++ b/lib/kitchen/driver/docker_cli.rb
@@ -60,10 +60,22 @@ module Kitchen
       end
 
       def create(state)
+        pre_create_command
         state[:image] = build(state) unless state[:image]
         state[:container_id] = run(state) unless state[:container_id]
       end
 
+      def pre_create_command
+        if config[:pre_create_command]
+          system(config[:pre_create_command])
+          if $?.exitstatus.nonzero?
+            raise ActionFailed,
+                  "pre_create_command '#{config[:pre_create_command]}' failed to execute \
+                  (exit status #{$?.exitstatus})"
+          end
+        end
+      end
+      
       def destroy(state)
         instance.transport.connection(state) do |conn|
           begin


### PR DESCRIPTION
This is following [equivalent work for kitchen-docker](https://github.com/test-kitchen/kitchen-docker/pull/249)

Example use case #1:  Logging into AWS ECR prior to running a kitchen test so the test images can be retrieved
Example use case #2:  Running `bundle exec berks update` to refresh the
Berksfile.lock prior to running tests