### PR TITLE
Added mount flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,17 @@ Examples:
     - container_b
 ```
 
+### mount
+
+Attach a filesystem mount to the container.
+
+Examples:
+
+```yml
+  mount: type=volume,source=my-volume,destination=/path/in/container
+```
+
+
 ### dockerfile
 
 Create test image using a supplied Dockerfile, instead of the default Dockerfile created.  

--- a/lib/kitchen/driver/docker_cli.rb
+++ b/lib/kitchen/driver/docker_cli.rb
@@ -137,6 +137,7 @@ module Kitchen
         Array(config[:publish]).each { |pub| cmd << " -p #{pub}" }
         Array(config[:volume]).each { |vol| cmd << " -v #{vol}" }
         Array(config[:volumes_from]).each { |vf| cmd << " --volumes-from #{vf}" }
+        Array(config[:mount]).each {|mount| cmd << " --mount #{mount}"}
         Array(config[:link]).each { |link| cmd << " --link #{link}" }
         Array(config[:expose]).each { |exp| cmd << " --expose #{exp}" }
         Array(config[:dns]).each {|dns| cmd << " --dns #{dns}"}


### PR DESCRIPTION
I wanted to be able to specify volume size when the container is created, which led me to the `--mount` flag.  It seemed like a simple enough change to add this capability, but I am new to Docker and Kitchen so if I've missed anything please let me know.